### PR TITLE
Analpa 2616 diagram bug

### DIFF
--- a/src/utils/PFBendParameterHelpers.js
+++ b/src/utils/PFBendParameterHelpers.js
@@ -75,18 +75,18 @@ function row(n, formik, isBend1) {
   const lim = isBend1 ? "ratio" : "angle";
   return (
     <Grid container item alignItems="flex-end" spacing={1} key={n}>
-      <Grid item xs={2}>
+      <Grid item xs={3}>
         {input(`PF_bend_${bend}_${n}`, formik)}
       </Grid>
-      <Grid item xs={2} />
-      <Grid item xs={2} />
-      <Grid item xs={2}>
+      <Grid item xs={1} />
+      {/* <Grid item xs={2} /> */}
+      <Grid item xs={3}>
         {n > 1 ? input(`bend_${lim}_lim_${n - 1}`, formik) : null}
       </Grid>
       <Grid item xs={2} paddingBottom={0.5}>
         {limText(n, symbol)}
       </Grid>
-      <Grid item xs={2}>
+      <Grid item xs={3}>
         {n < 5 ? input(`bend_${lim}_lim_${n}`, formik) : null}
       </Grid>
     </Grid>
@@ -116,7 +116,7 @@ export function headerAndTooltip(
 ) {
   return (
     <Grid item xs={12} container alignItems="center">
-      <Grid item xs={6}>
+      <Grid item xs={4}>
         <Typography
           style={{ fontSize: 14, fontWeight: 550 }}
           color="textSecondary"

--- a/src/views/DisplayRIVResultsDiagramView.js
+++ b/src/views/DisplayRIVResultsDiagramView.js
@@ -120,6 +120,10 @@ export default function DisplayRIVResultsDiagramView(props) {
     setSelectedRowIndex(data.activePayload[0].payload.point_index);
   };
 
+  const maxDataValue = Math.ceil(
+    Math.max(...displayRowResults.map((entry) => entry.RISK_INDEX_SUM)) + 2
+  );
+
   return (
     <div
       role="TabPanelComponent"
@@ -142,20 +146,18 @@ export default function DisplayRIVResultsDiagramView(props) {
             <Line type="monotone" dataKey="RISK_INDEX_SUM" stroke="#8884d8" />
             <CartesianGrid stroke="#ccc" strokeDasharray="3 3" />
             <XAxis dataKey="GDO_GID" angle={-45} textAnchor={"end"} />
-            <YAxis />
+            <YAxis domain={[0, maxDataValue]} />
             <Tooltip trigger="click" content={<CustomTooltipRender />} />
             <ReferenceArea
               y1={0}
-              y2={RIVTrafficLight.green}
-              label="Green"
+              y2={Math.min(maxDataValue, RIVTrafficLight.green)}
               stroke="Green"
               fill="green"
               fillOpacity={0.1}
             />
             <ReferenceArea
               y1={RIVTrafficLight.green}
-              y2={RIVTrafficLight.yellow}
-              label="Yellow"
+              y2={Math.min(maxDataValue, RIVTrafficLight.yellow)}
               stroke="yellow"
               fill="yellow"
               fillOpacity={0.1}
@@ -163,7 +165,6 @@ export default function DisplayRIVResultsDiagramView(props) {
             <ReferenceArea
               y1={RIVTrafficLight.yellow}
               y2={RIVTrafficLight.red}
-              label="Red"
               stroke="red"
               fill="red"
               fillOpacity={0.1}


### PR DESCRIPTION
https://extranet.vayla.fi/jira/browse/ANALPA-2616

Diagram background did not fill correctly when color boundaries were higher than y axis. Now if maximum value is smaller than boundary it will be selected as Y axis.