### PR TITLE
Korjaus nginx:n caching-ongelmaan

### DIFF
--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -28,18 +28,22 @@ FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/nginx:1.23.2-alpine
 # Used by nginx
 ARG PROXY_URL
 ARG REACT_APP_BASE_REST_URL
-
-ENV PROXY_URL=${PROXY_URL}
-ENV REACT_APP_BASE_REST_URL=${REACT_APP_BASE_REST_URL}
 RUN echo ${PROXY_URL}
 RUN echo ${REACT_APP_BASE_REST_URL}
 
 COPY --from=builder /app/build /var/www
-COPY ./nginx/riski.conf.template /nginx.conf.template
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-# envsubst to substitute ENV variables (PROXY_URL, REACT_APP_BASE_REST_URL) in config
-CMD ["/bin/sh" , "-c" , "envsubst < /nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+COPY ./nginx/riski.conf.template /etc/nginx/nginx.conf
+
+# substitute variables (PROXY_URL, REACT_APP_BASE_REST_URL) in config at build time
+RUN sed -i 's|!REACT_APP_BASE_REST_URL!|'${REACT_APP_BASE_REST_URL}'|' /etc/nginx/nginx.conf
+RUN sed -i 's|!PROXY_URL!|'${PROXY_URL}'|' /etc/nginx/nginx.conf
+
+# substitute nameserver url in nginx conf at runtime
+CMD [ "/bin/sh", "-c", "sed -i 's|!NAMESERVER!|'$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')'|' /etc/nginx/nginx.conf \
+  && exec nginx -g 'daemon off;'" ]
+

--- a/nginx/riski.conf.template
+++ b/nginx/riski.conf.template
@@ -15,8 +15,11 @@ http {
       index index.html;
     }
 
-    location /${REACT_APP_BASE_REST_URL} {
-      proxy_pass ${PROXY_URL};
+    resolver !NAMESERVER!;
+    set $upstream !PROXY_URL!;
+
+    location /!REACT_APP_BASE_REST_URL! {
+      proxy_pass $upstream;
       proxy_connect_timeout 300s;
       proxy_send_timeout 300;
       proxy_read_timeout 300s;


### PR DESCRIPTION
Sama korjaus mikä tehtiin tietokatalogi-frontendiin. Ongelma oli, että nginx cachettaa aws load balancerin ip-osoitteen, vaikka kyseinen ip-osoite muuttuu joskus. Nginx osaa tehdä tarvittavat dns-kyselyt uudestaan, jos sen configissa määritellään oikea nameserver resolverilla, ja jos proxy-pass:issa käytetään muuttujaa.

Tehtiin korjaus Dockerfileen ja nginx.conf:iin, sekä muutokset ympäristömuuttujien käyttöön (nyt toimii sed:illä).
Testaus:
  - testiympäristö toimii (korjaus on jo viety sinne)
  - tarvittaessa komentoja voi toki kokeilla ajaa sopivassa ympäristössä käsin