### PR TITLE
Fixed input fields resetting to default upon tab switch

### DIFF
--- a/src/components/CalculateRIV.js
+++ b/src/components/CalculateRIV.js
@@ -19,16 +19,22 @@ import SelectedWayareaContext from "contexts/SelectedWayareaContext";
 import SelectedBoatContext from "contexts/SelectedBoatContext";
 import GDOGIDListContext from "contexts/SelectedGDOGIDContext";
 import SelectedWayareaWithNoGDOGIDContext from "contexts/SelectedWayareaWithNoGDOGIDContext";
+import CalculationIntervalContext from "../contexts/CalculationIntervalContext";
+import SelectedWayareaChangedContext from "../contexts/SelectedWayareaChangedContext";
+import AllGDOGIDSContext from "../contexts/AllGDOGIDSContext";
 
 function CalculateRIV() {
   const [RIVResults, setRIVResults] = useState([]);
   const [userInput, setUserInput] = useState(userInputDefault);
   const [selectedRowIndex, setSelectedRowIndex] = useState(null);
   const [selectedWayarea, setSelectedWayarea] = useState(null);
+  const [selectedWayareaChanged, setSelectedWayareaChanged] = useState(false);
   const [selectedBoat, setSelectedBoat] = useState(null);
   const [selectedGDOGIDString, setSelectedGDOGIDString] = useState("");
   const [selectedWayareaWithNoGDOGID, setSelectedWayareaWithNoGDOGID] =
     useState(true);
+  const [allGDOGIDs, setAllGDOGIDs] = useState([]);
+  const [calculationInterval, setCalculationInterval] = useState(10);
 
   const [RIVTrafficLight, setRIVTraffiLight] = useState({
     green: 10,
@@ -63,55 +69,85 @@ function CalculateRIV() {
                 <SelectedWayareaContext.Provider
                   value={{ selectedWayarea, setSelectedWayarea }}
                 >
-                  <SelectedWayareaWithNoGDOGIDContext.Provider
-                    value={{
-                      selectedWayareaWithNoGDOGID,
-                      setSelectedWayareaWithNoGDOGID,
-                    }}
+                  <AllGDOGIDSContext.Provider
+                    value={{ allGDOGIDs, setAllGDOGIDs }}
                   >
-                    <GDOGIDListContext.Provider
-                      value={{ selectedGDOGIDString, setSelectedGDOGIDString }}
+                    <SelectedWayareaChangedContext.Provider
+                      value={{
+                        selectedWayareaChanged,
+                        setSelectedWayareaChanged,
+                      }}
                     >
-                      <SelectedBoatContext.Provider
-                        value={{ selectedBoat, setSelectedBoat }}
+                      <SelectedWayareaWithNoGDOGIDContext.Provider
+                        value={{
+                          selectedWayareaWithNoGDOGID,
+                          setSelectedWayareaWithNoGDOGID,
+                        }}
                       >
-                        <SelectedIndexContext.Provider
-                          value={{ selectedRowIndex, setSelectedRowIndex }}
+                        <CalculationIntervalContext.Provider
+                          value={{
+                            calculationInterval,
+                            setCalculationInterval,
+                          }}
                         >
-                          <MapPointClickedContext.Provider
-                            value={{ mapPointClicked, setMapPointClicked }}
+                          <GDOGIDListContext.Provider
+                            value={{
+                              selectedGDOGIDString,
+                              setSelectedGDOGIDString,
+                            }}
                           >
-                            <TableRowClickedContext.Provider
-                              value={{ tableRowClicked, setTableRowClicked }}
+                            <SelectedBoatContext.Provider
+                              value={{ selectedBoat, setSelectedBoat }}
                             >
-                              <DiagramPointClickedContext.Provider
+                              <SelectedIndexContext.Provider
                                 value={{
-                                  diagramPointClicked,
-                                  setDiagramPointClicked,
+                                  selectedRowIndex,
+                                  setSelectedRowIndex,
                                 }}
                               >
-                                <NotificationComponent />
-                                <LoadingSpinner />
-                                <div className="main-wrapper">
-                                  <div className="parameter-and-riv-wrapper">
-                                    <div className="parameter-wrapper">
-                                      <ParameterTabsComponent />
-                                    </div>
-                                    <div className="riv-wrapper">
-                                      <RIVResultsTabsComponent />
-                                    </div>
-                                  </div>
-                                  <div className="map-wrapper ">
-                                    <MapView />
-                                  </div>
-                                </div>
-                              </DiagramPointClickedContext.Provider>
-                            </TableRowClickedContext.Provider>
-                          </MapPointClickedContext.Provider>
-                        </SelectedIndexContext.Provider>
-                      </SelectedBoatContext.Provider>
-                    </GDOGIDListContext.Provider>
-                  </SelectedWayareaWithNoGDOGIDContext.Provider>
+                                <MapPointClickedContext.Provider
+                                  value={{
+                                    mapPointClicked,
+                                    setMapPointClicked,
+                                  }}
+                                >
+                                  <TableRowClickedContext.Provider
+                                    value={{
+                                      tableRowClicked,
+                                      setTableRowClicked,
+                                    }}
+                                  >
+                                    <DiagramPointClickedContext.Provider
+                                      value={{
+                                        diagramPointClicked,
+                                        setDiagramPointClicked,
+                                      }}
+                                    >
+                                      <NotificationComponent />
+                                      <LoadingSpinner />
+                                      <div className="main-wrapper">
+                                        <div className="parameter-and-riv-wrapper">
+                                          <div className="parameter-wrapper">
+                                            <ParameterTabsComponent />
+                                          </div>
+                                          <div className="riv-wrapper">
+                                            <RIVResultsTabsComponent />
+                                          </div>
+                                        </div>
+                                        <div className="map-wrapper ">
+                                          <MapView />
+                                        </div>
+                                      </div>
+                                    </DiagramPointClickedContext.Provider>
+                                  </TableRowClickedContext.Provider>
+                                </MapPointClickedContext.Provider>
+                              </SelectedIndexContext.Provider>
+                            </SelectedBoatContext.Provider>
+                          </GDOGIDListContext.Provider>
+                        </CalculationIntervalContext.Provider>
+                      </SelectedWayareaWithNoGDOGIDContext.Provider>
+                    </SelectedWayareaChangedContext.Provider>
+                  </AllGDOGIDSContext.Provider>
                 </SelectedWayareaContext.Provider>
               </WayareaPolygonContext.Provider>
             </NotificationContext.Provider>

--- a/src/components/UserInputComponent/Boat/BoatMenuComponent.js
+++ b/src/components/UserInputComponent/Boat/BoatMenuComponent.js
@@ -14,11 +14,18 @@ import userInputDefault from "constants/UserInputDefault";
 import CustomNumber from "components/customInputs/CustomNumber";
 
 export default function BoatMenuComponent(props) {
+  const formatInputString = (boat) =>
+    boat
+      ? `${boat.JNRO} - ${boat.VAY_NIMISU}, pituus: ${boat.PITUUS}, leveys: ${boat.LEVEYS},  syväys: ${boat.SYVAYS}`
+      : "";
+
   const { formik } = props;
   const [defaultBoats, setDefaultBoats] = useState([]);
   const { setNotificationStatus } = useContext(NotificationContext);
   const { selectedBoat, setSelectedBoat } = useContext(SelectedBoatContext);
-  const [boatInputString, setBoatInputString] = useState("");
+  const [boatInputString, setBoatInputString] = useState(
+    formatInputString(selectedBoat)
+  );
   const [showOld, setShowOld] = useState(false);
 
   useEffect(() => {
@@ -35,9 +42,6 @@ export default function BoatMenuComponent(props) {
         });
       });
   }, []);
-
-  const formatInputString = (boat) =>
-    `${boat.JNRO} - ${boat.VAY_NIMISU}, pituus: ${boat.PITUUS}, leveys: ${boat.LEVEYS},  syväys: ${boat.SYVAYS}`;
 
   function handleMenuItemClick(event, newValue) {
     setChosenBoatFormikValue(newValue);

--- a/src/components/UserInputComponent/GDOGIDMenuComponent.js
+++ b/src/components/UserInputComponent/GDOGIDMenuComponent.js
@@ -18,6 +18,8 @@ import SelectedGDOGIDContext from "contexts/SelectedGDOGIDContext";
 import SpinnerVisibilityContext from "contexts/SpinnerVisibilityContext";
 import SelectedWayareaWithNoGDOGIDContext from "contexts/SelectedWayareaWithNoGDOGIDContext";
 import FairwayWidth from "./FairwayWidth";
+import SelectedWayareaChangedContext from "../../contexts/SelectedWayareaChangedContext";
+import AllGDOGIDSContext from "../../contexts/AllGDOGIDSContext";
 
 export default function GDOGIDMenuComponent(props) {
   const { name, formik } = props;
@@ -25,8 +27,11 @@ export default function GDOGIDMenuComponent(props) {
   const [field, meta] = useField(name);
   const { setNotificationStatus } = useContext(NotificationContext);
   const { setSpinnerVisible } = useContext(SpinnerVisibilityContext);
-  const [allGDOGIDs, setAllGDOGIDs] = useState([]);
+  const { allGDOGIDs, setAllGDOGIDs } = useContext(AllGDOGIDSContext);
   const { selectedWayarea } = useContext(SelectedWayareaContext);
+  const { selectedWayareaChanged, setSelectedWayareaChanged } = useContext(
+    SelectedWayareaChangedContext
+  );
   const { selectedGDOGIDString, setSelectedGDOGIDString } = useContext(
     SelectedGDOGIDContext
   );
@@ -48,9 +53,9 @@ export default function GDOGIDMenuComponent(props) {
   }
 
   useEffect(() => {
-    setChosenGDOGIDFormikValue("");
-    setSelectedGDOGIDString("");
-    if (selectedWayarea) {
+    if (selectedWayarea && selectedWayareaChanged) {
+      setChosenGDOGIDFormikValue("");
+      setSelectedGDOGIDString("");
       setSpinnerVisible(true);
 
       const path = "gdo_gids_for_vaylat";
@@ -81,9 +86,10 @@ export default function GDOGIDMenuComponent(props) {
         })
         .finally(() => {
           setSpinnerVisible(false);
+          setSelectedWayareaChanged(false);
         });
     }
-  }, [selectedWayarea]);
+  }, [selectedWayarea, selectedWayareaChanged]);
 
   const handleMenuItemClick = (event, newValue) => {
     setInvalidFieldInput(false);

--- a/src/components/UserInputComponent/WayareaComponent.js
+++ b/src/components/UserInputComponent/WayareaComponent.js
@@ -17,6 +17,8 @@ import NotificationContext from "contexts/NotificationContext";
 import { useField } from "formik";
 import Form from "react-bootstrap/Form";
 import SelectedWayareaContext from "contexts/SelectedWayareaContext";
+import CalculationIntervalContext from "../../contexts/CalculationIntervalContext";
+import SelectedWayareaChangedContext from "../../contexts/SelectedWayareaChangedContext";
 
 export default function WayareaComponent(props) {
   const formatInputString = (wayarea) =>
@@ -31,10 +33,15 @@ export default function WayareaComponent(props) {
   const { selectedWayarea, setSelectedWayarea } = useContext(
     SelectedWayareaContext
   );
+  const { setSelectedWayareaChanged } = useContext(
+    SelectedWayareaChangedContext
+  );
   const [wayareaInputString, setWayareaInputString] = useState(
     formatInputString(selectedWayarea)
   );
-  const [calculationInterval, setCalculationInterval] = useState(10);
+  const { calculationInterval, setCalculationInterval } = useContext(
+    CalculationIntervalContext
+  );
   const calculationIntervalOptions = [
     10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 250, 500, 750, 1000,
   ];
@@ -84,12 +91,14 @@ export default function WayareaComponent(props) {
     if (value === "") {
       setChosenWayareaFormikValue(null);
       setSelectedWayarea(null);
+      setSelectedWayareaChanged(true);
     }
   };
 
   const handleMenuItemClick = (event, newValue) => {
     setChosenWayareaFormikValue(newValue);
     setSelectedWayarea(newValue);
+    setSelectedWayareaChanged(true);
     // Ternary operator needed since when the user clears the field, this is run and newValue is null
     setWayareaInputString(newValue ? formatInputString(newValue) : "");
   };

--- a/src/components/UserInputComponent/WayareaComponent.js
+++ b/src/components/UserInputComponent/WayareaComponent.js
@@ -121,7 +121,7 @@ export default function WayareaComponent(props) {
             <Tooltip
               placement="right"
               arrow
-              title={meta.error}
+              title={!formik.dirty ? "VAYLAT id vaaditaan" : meta.error}
               id="wayarea-tooltip"
             >
               <Autocomplete
@@ -141,7 +141,7 @@ export default function WayareaComponent(props) {
                 size="small"
                 renderInput={(params) => (
                   <TextField
-                    error={!!meta.error}
+                    error={!!meta.error || !formik.dirty}
                     style={{ backgroundColor: "white" }}
                     {...params}
                     required

--- a/src/contexts/AllGDOGIDSContext.js
+++ b/src/contexts/AllGDOGIDSContext.js
@@ -1,0 +1,5 @@
+const { createContext } = require("react");
+
+const AllGDOGIDSContext = createContext(null);
+
+export default AllGDOGIDSContext;

--- a/src/contexts/CalculationIntervalContext.js
+++ b/src/contexts/CalculationIntervalContext.js
@@ -1,0 +1,5 @@
+const { createContext } = require("react");
+
+const CalculationIntervalContext = createContext(null);
+
+export default CalculationIntervalContext;

--- a/src/contexts/SelectedWayareaChangedContext.js
+++ b/src/contexts/SelectedWayareaChangedContext.js
@@ -1,0 +1,5 @@
+const { createContext } = require("react");
+
+const SelectedWayareaChangedContext = createContext(null);
+
+export default SelectedWayareaChangedContext;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "checkJs": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "checkJs": false
-  }
-}


### PR DESCRIPTION
<!--
PR topic format:
ANALPA-1234: PR for my feature
-->
## Jira issue

<!--
Add link to Jira issue here. Format basic link:
https://extranet.vayla.fi/jira/browse/ANALPA-3212
-->

https://extranet.vayla.fi/jira/browse/ANALPA-3212

## Description

This PR fixes the bug where the input fields _Pisteiden väli_, _S-mutkan laskenta_, and _Valitse alus_ reset to their default values when switching tabs. All other input fields have been inspected and non other reset to default upon tab switch.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🏭 Code Refactor
- [ ] 🏋🏼‍♀️ Performance Improvements
- [ ] ✅ Test
- [ ] 🦾 CI/CD

## Added tests?

- [ ] 👍 yes
- [x] 👻 no, because they aren't needed
- [ ] 🙋 no, because I need help

NOTE! Not added yet, since the layout of the components in the tabs are up for change as we're currently waiting for feedback from the clients.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 👨🏻‍💻 documented in code: docstrings and typing
- [x] 🙅 no documentation needed

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] I have followed good coding conventions, eg [these](https://peps.python.org/pep-0008/)
- [x] There is no commented out code in this PR
- [ ] The code has been formatted using **isort .**, **pre-commit run --all-files**
- [x] Tests have been run and they pass
- [x] New or updated dependencies have been added to `requirements.txt` and/or `requirements_dev.txt`
